### PR TITLE
create-sudo-user (#5)

### DIFF
--- a/group_vars/all/variables.yml
+++ b/group_vars/all/variables.yml
@@ -1,3 +1,4 @@
 ---
 
 test: "hi there"
+default_user: "pi"

--- a/group_vars/all/variables.yml
+++ b/group_vars/all/variables.yml
@@ -1,4 +1,5 @@
 ---
 
-test: "hi there"
-default_user: "pi"
+ansible_default_user: "pi"
+ansible_user: "{{ ansible_default_user }}"
+ansible_port: 22

--- a/init.yml
+++ b/init.yml
@@ -1,8 +1,12 @@
 ---
 
 - hosts: all
-  remote_user: "{{ default_user }}"
+  remote_user: "{{ ansible_default_user }}"
   roles:
     - role: create-sudo-user
+
+- hosts: all
+  remote_user: "{{ ansible_user }}"
+  roles:
     - role: authorize_ssh
     - role: ssh-config-build

--- a/init.yml
+++ b/init.yml
@@ -1,6 +1,8 @@
 ---
 
 - hosts: all
+  remote_user: "{{ default_user }}"
   roles:
+    - role: create-sudo-user
     - role: authorize_ssh
     - role: ssh-config-build

--- a/roles/create-sudo-user/tasks/main.yml
+++ b/roles/create-sudo-user/tasks/main.yml
@@ -1,17 +1,21 @@
 ---
 
-- name: create a sudo user
-  user:
-    name: "{{ ansible_ssh_user }}"
+- name: create wheel group
+  become: true
+  group:
+    name: wheel
     state: present
-    groups: "{{ ansible_ssh_user }} adm dialout cdrom sudo audio video plugdev games users input netdev spi i2c gpio wheel"
+
+- name: create a sudo user
+  become: true
+  user:
+    name: "{{ ansible_user }}"
+    state: present
+    groups: "{{ ansible_user }},adm,dialout,cdrom,sudo,audio,video,plugdev,games,users,input,netdev,spi,i2c,gpio,wheel"
     password: "{{ ansible_ssh_pass }}"
 
-- lineinfile:
-    line: "%wheel         ALL = (ALL) NOPASSWD: ALL"
-    path: /etc/sudoers
-
 - name: allow wheel group to have passwordless sudo
+  become: true
   lineinfile:
     path: /etc/sudoers
     state: present

--- a/roles/create-sudo-user/tasks/main.yml
+++ b/roles/create-sudo-user/tasks/main.yml
@@ -1,10 +1,19 @@
 ---
 
-- name: create wheel group
+- name: Make sure we have a 'wheel' group
   become: true
   group:
     name: wheel
     state: present
+
+- name: Allow 'wheel' group to have passwordless sudo
+  become: true
+  lineinfile:
+    dest: /etc/sudoers
+    state: present
+    regexp: '^%wheel'
+    line: '%wheel ALL=(ALL) NOPASSWD: ALL'
+    validate: 'visudo -cf %s'
 
 - name: create a sudo user
   become: true
@@ -13,12 +22,3 @@
     state: present
     groups: "{{ ansible_user }},adm,dialout,cdrom,sudo,audio,video,plugdev,games,users,input,netdev,spi,i2c,gpio,wheel"
     password: "{{ ansible_ssh_pass }}"
-
-- name: allow wheel group to have passwordless sudo
-  become: true
-  lineinfile:
-    path: /etc/sudoers
-    state: present
-    regexp: '^%wheel'
-    line: '%wheel ALL=(ALL) NOPASSWD=ALL'
-    validate: 'visudo -cf %s'

--- a/roles/create-sudo-user/tasks/main.yml
+++ b/roles/create-sudo-user/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: create a sudo user
+  user:
+    name: "{{ remote_sudo_user }}"
+    state: present
+    # group: "{{ remote_sudo_user }}"
+    groups: pi adm dialout cdrom sudo audio video plugdev games users input netdev spi i2c gpio wheel
+    password: "{{ ansible_ssh_pass }}"
+
+- lineinfile:
+    line: "%wheel         ALL = (ALL) NOPASSWD: ALL"
+    path: /etc/sudoers

--- a/roles/create-sudo-user/tasks/main.yml
+++ b/roles/create-sudo-user/tasks/main.yml
@@ -2,12 +2,19 @@
 
 - name: create a sudo user
   user:
-    name: "{{ remote_sudo_user }}"
+    name: "{{ ansible_ssh_user }}"
     state: present
-    # group: "{{ remote_sudo_user }}"
-    groups: pi adm dialout cdrom sudo audio video plugdev games users input netdev spi i2c gpio wheel
+    groups: "{{ ansible_ssh_user }} adm dialout cdrom sudo audio video plugdev games users input netdev spi i2c gpio wheel"
     password: "{{ ansible_ssh_pass }}"
 
 - lineinfile:
     line: "%wheel         ALL = (ALL) NOPASSWD: ALL"
     path: /etc/sudoers
+
+- name: allow wheel group to have passwordless sudo
+  lineinfile:
+    path: /etc/sudoers
+    state: present
+    regexp: '^%wheel'
+    line: '%wheel ALL=(ALL) NOPASSWD=ALL'
+    validate: 'visudo -cf %s'

--- a/roles/ssh-config-build/tasks/main.yml
+++ b/roles/ssh-config-build/tasks/main.yml
@@ -18,9 +18,9 @@
         block: |
 
           Host {{ environment_name }}-{{ inventory_hostname }}
-          Hostname {{ ansible_ssh_host }}
+          Hostname {{ ansible_host }}
           User {{ ansible_user }}
-          Port 22
+          Port {{ ansible_port }}
 
 
     # include env config file in main


### PR DESCRIPTION
- new role: create-sudo-user
  - add role to init.yml
  - creates sudo user and allows passwordless sudo under wheel group
- set default box username under var: ansible_default_user

closes #5 
